### PR TITLE
Add `hookConsole` method

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,9 @@
+const {remote} = require('electron');
+const logger = require('.');
+
+const defaultsNameSpace = '__ELECTRON_TIMBER_DEFAULTS__';
+const {shouldHookConsole} = remote.getGlobal(defaultsNameSpace);
+
+if (shouldHookConsole) {
+	logger.hookConsole();
+}

--- a/test/fixture/index_hookConsole.js
+++ b/test/fixture/index_hookConsole.js
@@ -1,5 +1,6 @@
 'use strict';
 const electron = require('electron');
+const delay = require('delay');
 const logger = require('../..');
 
 let mainWindow;
@@ -7,7 +8,7 @@ electron.app.on('ready', async () => {
 	mainWindow = new electron.BrowserWindow();
 	mainWindow.loadURL(`file://${__dirname}/index.html?test=hookConsole`);
 
-	let unhook = logger.hookConsole();
+	let unhook = logger.hookConsole({ main: true, renderer: false });
 	console.log('Main log console');
 	console.warn('Main warn console');
 	unhook();

--- a/test/fixture/index_hookConsole.js
+++ b/test/fixture/index_hookConsole.js
@@ -1,0 +1,32 @@
+'use strict';
+const electron = require('electron');
+const logger = require('../..');
+
+let mainWindow;
+electron.app.on('ready', async () => {
+	mainWindow = new electron.BrowserWindow();
+	mainWindow.loadURL(`file://${__dirname}/index.html?test=hookConsole`);
+
+	let unhook = logger.hookConsole();
+	console.log('Main log console');
+	console.warn('Main warn console');
+	unhook();
+	console.log('Main log console');
+	console.warn('Main warn console');
+
+	unhook = logger.hookConsole();
+	console.error('Main error console');
+	console.time('Main timer console');
+	console.timeEnd('Main timer console');
+	unhook();
+	console.error('Main error console');
+	console.time('Main timer console');
+	console.timeEnd('Main timer console');
+
+	const customLogger = logger.create({name: 'custom', logLevel: 'info'});
+	try {
+		customLogger.hookConsole();
+	} catch (err) {
+		console.log(err.message);
+	}
+});

--- a/test/fixture/index_logLevel.js
+++ b/test/fixture/index_logLevel.js
@@ -1,0 +1,19 @@
+'use strict';
+const electron = require('electron');
+const logger = require('../..');
+
+let mainWindow;
+electron.app.on('ready', async () => {
+	mainWindow = new electron.BrowserWindow();
+	mainWindow.loadURL(`file://${__dirname}/index.html?test=logLevel`);
+
+	const customLogger = logger.create({name: 'custom', logLevel: 'info'});
+
+	electron.ipcMain.on('setDefaults', (event, newDefaults) => {
+		logger.setDefaults(newDefaults);
+	});
+	electron.ipcMain.on('logger', (event, method, ...args) => {
+		logger[method](...args);
+		customLogger[method](...args);
+	});
+});

--- a/test/fixture/renderer.js
+++ b/test/fixture/renderer.js
@@ -2,12 +2,33 @@
 const electron = require('electron');
 const logger = require('../..');
 
-logger.log('Renderer log');
-logger.warn('Renderer warn');
-logger.error('Renderer error');
-logger.time('Renderer timer');
-logger.timeEnd('Renderer timer');
+const test = (new URLSearchParams(window.location.search)).get('test');
 
-electron.ipcRenderer.on('logger', (event, method, ...args) => {
-    logger[method](...args);
-});
+// Run different code for different tests
+if (test == 'hookConsole') {
+	let unhook = logger.hookConsole();
+	console.log('Renderer log console');
+	console.warn('Renderer warn console');
+	unhook();
+	console.log('Renderer log console');
+	console.warn('Renderer warn console');
+
+	unhook = logger.hookConsole();
+	console.error('Renderer error console');
+	console.time('Renderer timer console');
+	console.timeEnd('Renderer timer console');
+	unhook();
+	console.error('Renderer error console');
+	console.time('Renderer timer console');
+	console.timeEnd('Renderer timer console');
+} else if (test == 'logLevel') {
+	electron.ipcRenderer.on('logger', (event, method, ...args) => {
+		logger[method](...args);
+	});
+} else {
+	logger.log('Renderer log');
+	logger.warn('Renderer warn');
+	logger.error('Renderer error');
+	logger.time('Renderer timer');
+	logger.timeEnd('Renderer timer');
+}

--- a/test/fixture/test.js
+++ b/test/fixture/test.js
@@ -15,9 +15,8 @@ const newApplication = (t, testFile = '.') => {
 	return t.context.app = app;
 };
 
-const cleanLogs = x => x.filter(x => {
-	return !x.includes('INFO:CONSOLE') && !x.includes('DnsConfig');
-});
+const ignores = ['INFO:CONSOLE', 'DnsConfig', 'security-warnings.js'];
+const cleanLogs = logs => logs.filter(log => ignores.every(x => !log.includes(x)));
 
 test('main', async t => {
 	const app = newApplication(t);

--- a/test/fixture/test.js
+++ b/test/fixture/test.js
@@ -117,7 +117,6 @@ test('hookConsole', async t => {
 	// 4 caught by the hooked console in main, and 4 in renderer
 	mainLogs = mainLogs.filter(x => x.includes('›'));
 	t.is(mainLogs.length, 8);
-
 	t.regex(mainLogs[0], /main › Main error console/);
 	t.regex(mainLogs[1], /main › Main log console/);
 	t.regex(mainLogs[2], /main › Main timer console/);


### PR DESCRIPTION
Here's my first attempt at implementing `hookConsole()`. (Fixes #9)

The tests were getting rather busy, so for the last two (`logLevel` and `hookConsole`) I moved them into separate files. I didn't want the test cases to pollute each others' logs.

Let me know what you think - suggestions, criticisms, etc.