### PR TITLE
Listen to channel only if not already listening

### DIFF
--- a/index.js
+++ b/index.js
@@ -201,13 +201,19 @@ module.exports = new Timber({
 
 if (is.main) {
 	const rendererLogger = new Timber({name: 'renderer'});
-	electron.ipcMain.on(logChannel, (event, data) => {
-		rendererLogger.log(...data);
-	});
-	electron.ipcMain.on(warnChannel, (event, data) => {
-		rendererLogger.warn(...data);
-	});
-	electron.ipcMain.on(errorChannel, (event, data) => {
-		rendererLogger.error(...data);
-	});
+	if (electron.ipcMain.listenerCount(logChannel) === 0) {
+		electron.ipcMain.on(logChannel, (event, data) => {
+			rendererLogger.log(...data);
+		});
+	}
+	if (electron.ipcMain.listenerCount(warnChannel) === 0) {
+		electron.ipcMain.on(warnChannel, (event, data) => {
+			rendererLogger.warn(...data);
+		});
+	}
+	if (electron.ipcMain.listenerCount(errorChannel) === 0) {
+		electron.ipcMain.on(errorChannel, (event, data) => {
+			rendererLogger.error(...data);
+		});
+	}
 }


### PR DESCRIPTION
I was facing a weird issue: I was getting the messages printed twice. This was due to extracting some of the funcionality of my electron app to a separate module. Both, the module and the electron app were using `electron-timber`.

Due to being required separately from both, I was getting the messages printed twice. The fix that this PR implements is checking that `ipcMain` has no listener on each channel before adding them, preventing the previous behavior.